### PR TITLE
Use shared_examples for rspec tests

### DIFF
--- a/spec/lib/elo/calculator_spec.rb
+++ b/spec/lib/elo/calculator_spec.rb
@@ -4,64 +4,58 @@ require "elo/calculator"
 describe Elo::Calculator do
   subject(:calculator) { Elo::Calculator }
 
+  shared_examples "calculates" do |description, method, params, outcome|
+    it description do
+      expect(calculator.send(method, *params)).to eq(outcome)
+    end
+  end
+
   describe ".p" do
-    it "calculates things" do
-      expect(calculator.p(630, 500, 3, 1, 20)).to eq(9.63)
+    [{ args: [630, 500, 3, 1, 20], result: 9.63 }].each do |params|
+      include_examples "calculates", "calculates correctly", :p, params[:args], params[:result]
     end
   end
 
   describe ".w" do
-    it "is 1 for a win" do
-      expect(calculator.w(1, 0)).to eq(1)
-      expect(calculator.w(4, 2)).to eq(1)
-      expect(calculator.w(9, 8)).to eq(1)
+    [[1,0], [4,2], [9,8]].each do |params|
+      include_examples "calculates", "is 1 for a win", :w, params, 1
     end
 
-    it "is .5 for a draw" do
-      expect(calculator.w(0, 0)).to eq(0.5)
-      expect(calculator.w(8, 8)).to eq(0.5)
-      expect(calculator.w(2, 2)).to eq(0.5)
+    [[0, 0], [8, 8], [2, 2]].each do |params|
+      include_examples "calculates", "is .5 for a draw", :w, params, 0.5
     end
 
-    it "is 0 for a loss" do
-      expect(calculator.w(0, 10)).to eq(0)
-      expect(calculator.w(6, 10)).to eq(0)
-      expect(calculator.w(4, 5)).to eq(0)
+    [[0, 10], [6, 10], [4, 5]].each do |params|
+      include_examples "calculates", "is 0 for a loss", :w, params, 0
     end
   end
 
   describe ".we" do
-    it "calculates correctly" do
-      expect(calculator.we(630, 500)).to eq(0.679)
-      expect(calculator.we(500, 630)).to eq(0.321)
-      expect(calculator.we(500, 480)).to eq(0.529)
-      expect(calculator.we(480, 500)).to eq(0.471)
+    [{ args: [630, 500], result: 0.679 },
+     { args: [500, 630], result: 0.321 },
+     { args: [500, 480], result: 0.529 },
+     { args: [480, 500], result: 0.471 }].each do |params|
+      include_examples "calculates", "calculates correctly", :we, params[:args], params[:result]
     end
   end
 
   describe ".g" do
-    it "is 1 for draws" do
-      expect(calculator.g(1, 1)).to eq(1.0)
-      expect(calculator.g(2, 2)).to eq(1.0)
-      expect(calculator.g(200, 200)).to eq(1.0)
+    [[1, 1], [2, 2], [200, 200]].each do |params|
+      include_examples "calculates", "is 1 for draws", :g, params, 1.0
     end
 
-    it "is 1 for +1 differential" do
-      expect(calculator.g(1, 2)).to eq(1.0)
-      expect(calculator.g(2, 1)).to eq(1.0)
-      expect(calculator.g(200, 199)).to eq(1.0)
+    [[1, 2],  [2, 1],  [200, 199]].each do |params|
+      include_examples "calculates", "is 1 for +1 differential", :g, params, 1.0
     end
 
-    it "is 3/2 when +2 differential" do
-      expect(calculator.g(1, 3)).to eq(1.5)
-      expect(calculator.g(10, 12)).to eq(1.5)
-      expect(calculator.g(4, 2)).to eq(1.5)
+    [[1, 3], [10, 12], [4, 2]].each do |params|
+      include_examples "calculates", "is 3/2 when +2 differential", :g, params, 1.5
     end
 
-    it "is (11 + difference)/8 when +3 or higher" do
-      expect(calculator.g(0, 3)).to eq(1.75)
-      expect(calculator.g(7, 0)).to eq(2.25)
-      expect(calculator.g(30, 40)).to eq(2.625)
+    [{ args: [0, 3],   result: 1.75 },
+     { args: [7, 0],   result: 2.25 },
+     { args: [30, 40], result: 2.625 }].each do |params|
+      include_examples "calculates", "is (11 + difference)/8 when +3 or higher", :g, params[:args], params[:result]
     end
   end
 end


### PR DESCRIPTION
The tests follow the same formula, so extract out the logic into a [shared example](https://www.relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) that can then be recalled. Makes it much easier to add in more tests.

The downside is instead of test failures looking like
```
Failures:

  1) Elo::Calculator.p calculates things
     Failure/Error: expect(calculator.p(630, 500, 3, 1, 20)).to eq(9.63)

       expected: 9.63
            got: 9.629999999999999

       (compared using ==)
     # ./spec/lib/elo/calculator_spec.rb:15:in `block (3 levels) in <top (required)>'
```

they look like
```
Failures:

  1) Elo::Calculator.p calculates correctly
     Failure/Error: expect(calculator.send(method, *params)).to eq(outcome)

       expected: 9.63
            got: 9.629999999999999

       (compared using ==)
     Shared Example Group: "calculates" called from ./spec/lib/elo/calculator_spec.rb:15
     # ./spec/lib/elo/calculator_spec.rb:9:in `block (3 levels) in <top (required)>'

Finished in 0.03002 seconds (files took 0.15652 seconds to load)
26 examples, 1 failure

Failed examples:

rspec './spec/lib/elo/calculator_spec.rb[1:1:1]' # Elo::Calculator.p calculates correctly
```

You can still see which test failed, but its a bit more opaque as it uses variables instead of hardcoded values.