### PR TITLE
Add additional test data for Calculator.p.

### DIFF
--- a/spec/lib/elo/calculator_spec.rb
+++ b/spec/lib/elo/calculator_spec.rb
@@ -11,7 +11,12 @@ describe Elo::Calculator do
   end
 
   describe ".p" do
-    [{ args: [630, 500, 3, 1, 20], result: 9.63 }].each do |params|
+    [{ args: [630, 500, 3, 1, 20], result: 9.63 },
+     { args: [630, 500, 1, 3, 20], result: -20.37 },
+     { args: [630, 500, 2, 2, 20], result: -3.58 },
+     { args: [500, 480, 3, 1, 20], result: 14.13 },
+     { args: [500, 480, 1, 3, 20], result: -15.87 },
+     { args: [500, 480, 2, 2, 20], result: -0.58 }].each do |params|
       include_examples "calculates", "calculates correctly", :p, params[:args], params[:result]
     end
   end


### PR DESCRIPTION
Addresses issue https://github.com/santouras/foosball/issues/17 by adding additional test data from the Wikipedia [World Football Elo Ratings](https://en.m.wikipedia.org/wiki/World_Football_Elo_Ratings) page.