### PR TITLE
Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/santouras/foosball.svg?branch=master)](https://travis-ci.org/santouras/foosball)
+
 # Foosball Elo Ranking App
 
 >“Oh, the places you'll go! There is fun to be done!


### PR DESCRIPTION
Created an account on Travis for our CI. Adding in the `.travis.yml` file [which says which language and what command to run](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A)

We don't need to enter the ruby version here as it is specified [in the .ruby-version file](https://docs.travis-ci.com/user/languages/ruby#Using-.ruby-version) that travis will pick up on